### PR TITLE
add books table schema definition

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if [[ \"$(basename \"$f\")\" == .env* ]]; then echo '{\"decision\":\"block\",\"reason\":\".env files should not be edited by Claude\"}'; fi; }"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == *.go ]] && docker compose exec -T api gofmt -w \"${f#$(pwd)/}\" || true; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Running gofmt..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/schema-apply/SKILL.md
+++ b/.claude/skills/schema-apply/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: schema-apply
+description: Atlasスキーマのdry-run確認と適用を実行するワークフロー。スキーマ変更の適用、テーブル追加・変更のDB反映、atlas schema applyに関するタスクで使用する。
+---
+
+# Schema Apply Workflow
+
+Atlas宣言的スキーマ管理のdry-run→承認→適用→検証ワークフローを実行する。
+
+## ステップ
+
+### 1. Dry-run（差分SQL確認）
+
+以下のコマンドで生成されるSQLをプレビューする。
+
+```bash
+docker compose run --rm atlas schema apply --env local --dry-run
+```
+
+出力された差分SQLをユーザーに提示し、意図通りの変更であるかを確認する。「Schema is synced, no changes to be made」と表示された場合は、スキーマ定義ファイルに変更がないことを伝えて終了する。
+
+### 2. 承認確認
+
+dry-runの結果を確認した上で、ユーザーに適用の承認を求める。承認が得られない場合はここで終了する。
+
+### 3. 適用
+
+承認後、以下のコマンドでスキーマを適用する。
+
+```bash
+docker compose run --rm atlas schema apply --env local --auto-approve
+```
+
+### 4. 検証
+
+適用後、以下のコマンドでテーブル一覧を表示し、変更が正しく反映されたことを確認する。
+
+```bash
+docker compose exec db psql -U user -d mare_scientiae -c '\dt'
+```
+
+特定テーブルの詳細構造を確認する場合は、`\d テーブル名` を使用する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,26 @@ docker-compose で以下の4サービスを構成する。
 | api | 自前ビルド（Go） | アプリケーション本体 |
 | db | postgres:18.3 | 開発用データベース |
 | test-db | postgres:18.3 | テスト用データベース（TDDで使用） |
-| atlas | arigaio/atlas | スキーマ管理（宣言的ワークフロー） |
+| atlas | arigaio/atlas:1.2.0 | スキーマ管理（宣言的ワークフロー） |
 
 ## スキーマ管理
 
-Atlas（宣言的スキーマ管理）を採用。Go公式レイアウトに従い、非Goファイルはプロジェクトルートに配置する。
+Atlas（宣言的スキーマ管理）を採用。Go公式レイアウトに従い、非Goファイルはプロジェクトルートに配置する。スキーマ適用は `/schema-apply` スキルを使用すること。
 
 ```
-atlas.hcl              … Atlas プロジェクト設定
+atlas.hcl              … Atlas プロジェクト設定（srcは配列で複数ディレクトリを指定）
 schemas/               … スキーマ宣言（テーブル定義）
   db/
     schema.hcl         … データベース定義（publicスキーマ）
-    tables/            … テーブル定義
+    tables/            … テーブル定義（*.pg.hcl）
+```
+
+テーブル定義ファイルは `schemas/db/tables/` に `<テーブル名>.pg.hcl` の命名規則で配置する。Atlasはディレクトリを再帰的にスキャンしないため、`atlas.hcl` の `src` に `schemas/db` と `schemas/db/tables` の両方を配列で指定している。
+
+```bash
+# スキーマ適用（dry-run）
+docker compose run --rm atlas schema apply --env local --dry-run
+
+# スキーマ適用
+docker compose run --rm atlas schema apply --env local --auto-approve
 ```

--- a/atlas.hcl
+++ b/atlas.hcl
@@ -16,6 +16,9 @@ locals {
 }
 
 env "local" {
-  src = "file://schemas/db"
+  src = [
+    "file://schemas/db",
+    "file://schemas/db/tables",
+  ]
   url = local.postgres_url.local
 }

--- a/schemas/db/tables/books.pg.hcl
+++ b/schemas/db/tables/books.pg.hcl
@@ -1,0 +1,50 @@
+table "books" {
+  schema = schema.public
+
+  column "id" {
+    type    = uuid
+    null    = false
+    default = sql("gen_random_uuid()")
+  }
+
+  column "google_books_id" {
+    type = varchar(50)
+    null = false
+  }
+
+  column "title" {
+    type = varchar(500)
+    null = false
+  }
+
+  column "subtitle" {
+    type = varchar(500)
+    null = true
+  }
+
+  column "authors" {
+    type = sql("text[]")
+    null = false
+  }
+
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  column "updated_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  index "idx_books_google_books_id" {
+    columns = [column.google_books_id]
+    unique  = true
+  }
+}


### PR DESCRIPTION
## Summary
- Atlasの宣言的スキーマ管理で`books`テーブルを定義（`schemas/db/tables/books.pg.hcl`）
- `atlas.hcl`の`src`を配列に変更し、`tables/`サブディレクトリのHCLファイルも読み込むように修正
- カラム: `id`(UUID PK), `google_books_id`(UNIQUE), `title`, `subtitle`, `authors`(text[]), `created_at`, `updated_at`

## Test plan
- [x] `docker compose run --rm atlas schema apply --env local --dry-run` で生成SQLが想定通りであることを確認
- [x] `docker compose run --rm atlas schema apply --env local` でDBに適用済み
- [x] `\d books` でテーブル構造・インデックスを確認済み

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)