### PR TITLE
Go言語のコード規約・テスト規約のClaude Code Rules設定

### DIFF
--- a/.claude/rules/backend/go-code-style.md
+++ b/.claude/rules/backend/go-code-style.md
@@ -1,0 +1,69 @@
+# Go Code Style Guide
+
+Google Go Style Guide (https://google.github.io/styleguide/go/) に準拠する。
+
+## 設計原則
+
+優先順位: **Clarity > Simplicity > Concision > Maintainability > Consistency**
+
+コードの目的と意図が読み手に明確であることを最優先とする。
+
+## 命名規則
+
+- MixedCaps を使用する。アンダースコアは使わない
+- 定数も MixedCaps とする（`ALL_CAPS` 禁止）
+- パッケージ名は小文字の単一単語（アンダースコア不可）
+- レシーバ名は1-2文字の短い省略形とし、型内で一貫させる（例: `Book` → `b`）
+- パッケージ名をエクスポート名に繰り返さない（`domain.Book` ✓、`domain.DomainBook` ✗）
+- initialisms はケースを統一する（`XMLAPI`、`GRPC`）
+- 関数名: 値を返す関数は名詞的、アクションを実行する関数は動詞的に命名する
+
+## パッケージ設計
+
+- `util`、`helper`、`common` などの汎用パッケージ名は禁止
+- パッケージごとに明確な単一責務を持たせる
+- パッケージ名から内容が推測できる命名にする
+
+## import
+
+- グループ順序: 標準ライブラリ → 外部パッケージ → 内部パッケージ
+- 各グループは空行で区切る
+- blank import（`_ "pkg"`）は `main` パッケージとテストファイルのみで使用する
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"helloworld/internal/domain"
+)
+```
+
+## エラーハンドリング
+
+- `error` は常に最後の戻り値として返す
+- sentinel error は `var Err... = errors.New()` で定義する
+- エラーラップにはプログラムによる検査が必要な場合 `%w` を使用し、システム境界では `%v` を使用する
+- `%w` はエラー文字列の末尾に配置する
+- エラーの判定には `errors.Is()` を使用する
+- blank identifier（`_`）でのエラー破棄は禁止
+- in-band エラーシグナル（-1、空文字列等の戻り値）は避け、追加の戻り値を使う
+
+## 関数シグネチャ
+
+- `context.Context` は第1引数として渡す（struct に埋め込まない）
+- 大きな関数は option struct または variadic options で分割する
+
+## フォーマット
+
+- `gofmt` 準拠
+- 固定行長の上限は設けない（長い行はリファクタリングで対応する）
+- インデント変更前や URL 中での行分割は回避する
+
+## 並行処理
+
+- goroutine のライフタイムを明示的かつ明確にする
+- context cancellation または `sync.WaitGroup` で終了を管理する
+- 結果を直接返す同期関数を優先し、非同期パターンは必要な場合のみ使用する

--- a/.claude/rules/backend/go-testing.md
+++ b/.claude/rules/backend/go-testing.md
@@ -39,7 +39,7 @@ for _, tt := range tests {
 
 ## `t.Error` vs `t.Fatal`
 
-- `t.Error` / `t.Errorf`: テスト継続可能な失敗に使用する。テーブル駆動テストのループ内では `continue` と組み合わせる
+- `t.Error` / `t.Errorf`: テスト継続可能な失敗に使用する
 - `t.Fatal` / `t.Fatalf`: セットアップの失敗や、後続チェックが無意味な場合のみ使用する
 - 別 goroutine からの fatal 呼び出しは禁止
 

--- a/.claude/rules/backend/go-testing.md
+++ b/.claude/rules/backend/go-testing.md
@@ -1,0 +1,79 @@
+# Go Testing Guide
+
+Google Go Style Guide (https://google.github.io/styleguide/go/) に準拠する。
+
+## テスト命名
+
+- テスト関数名は `Test` プレフィックス + 大文字始まり
+- `TestFunctionName_Scenario` パターンで命名する
+
+## テーブル駆動テスト
+
+- 無名構造体スライスでテストケースを定義する（`name`, 入力値, `want`, `wantErr` フィールド）
+- `for _, tt := range tests` でイテレーションする
+- `t.Run(tt.name, func(t *testing.T) { ... })` でサブテスト化する
+- テストケースの追加が容易な構造を維持する
+
+```go
+tests := []struct {
+	name    string
+	input   int
+	want    int
+	wantErr error
+}{
+	{"positive", 10, 5, nil},
+	{"zero division", 0, 0, ErrDivideByZero},
+}
+for _, tt := range tests {
+	t.Run(tt.name, func(t *testing.T) {
+		got, err := Divide(tt.input, 2)
+		// assertions...
+	})
+}
+```
+
+## アサーション
+
+- assertion library は使用しない。標準の比較演算を使う
+- 複雑な構造体比較には `cmp` パッケージ（`github.com/google/go-cmp/cmp`）を使用する
+
+## `t.Error` vs `t.Fatal`
+
+- `t.Error` / `t.Errorf`: テスト継続可能な失敗に使用する。テーブル駆動テストのループ内では `continue` と組み合わせる
+- `t.Fatal` / `t.Fatalf`: セットアップの失敗や、後続チェックが無意味な場合のみ使用する
+- 別 goroutine からの fatal 呼び出しは禁止
+
+## 失敗メッセージ
+
+- 形式: `"FuncName(%v) = %v, want %v"`
+- actual（実際の結果）を先、expected（期待値）を後に記述する
+- 関数名と入力値を含めることで失敗箇所を特定しやすくする
+
+```go
+if got != tt.want {
+	t.Errorf("Add(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+}
+```
+
+## ヘルパー関数
+
+- テストヘルパー関数の冒頭で `t.Helper()` を呼ぶ
+- これによりエラー発生箇所がヘルパー内ではなく呼び出し元として報告される
+- `*testing.T`、`testing.TB`、カスタムインターフェースを引数に取れる
+
+## クリーンアップ
+
+- `t.Cleanup()` でティアダウン処理を登録する（`defer` より優先）
+- テスト終了時（skip、fatal、panic 含む）に確実に実行される
+- サブテスト内でもネスト可能（逆順で実行される）
+
+## ベンチマーク
+
+- `BenchmarkXxx(b *testing.B)` パターンで命名する
+- `b.N` ループが必須
+- `b.Run()` でサブベンチマークを作成する
+
+## テスト構造
+
+- テストロジックは Test 関数内に保持し、過度な抽象化を避ける
+- バリデーション関数からはエラーを返すことを優先する（assertion ヘルパーより）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,12 @@ domain層は外部パッケージに一切依存しない。infrastructure層は
 
 docker-compose で以下の4サービスを構成する。
 
-| サービス | イメージ | 役割 |
-|---|---|---|
-| api | 自前ビルド（Go） | アプリケーション本体 |
-| db | postgres:18.3 | 開発用データベース |
-| test-db | postgres:18.3 | テスト用データベース（TDDで使用） |
-| atlas | arigaio/atlas:1.2.0 | スキーマ管理（宣言的ワークフロー） |
+| サービス | イメージ            | 役割                               |
+| -------- | ------------------- | ---------------------------------- |
+| api      | 自前ビルド（Go）    | アプリケーション本体               |
+| db       | postgres:18.3       | 開発用データベース                 |
+| test-db  | postgres:18.3       | テスト用データベース（TDDで使用）  |
+| atlas    | arigaio/atlas:1.2.0 | スキーマ管理（宣言的ワークフロー） |
 
 ## スキーマ管理
 
@@ -105,13 +105,13 @@ docker compose run --rm atlas schema apply --env local --auto-approve
 - `code-simplifier` プラグインを使用してコードの簡潔さ・可読性を維持する
 - `security-guideline` プラグインに準拠し、セキュリティを考慮した実装を行う
 
-### 4. レビュー
-
-- `code-review` コマンドを使用してコードレビューを実施する
-- レビューで指摘された項目をユーザーに提示し、修正が必要な箇所の指示を受ける
-- 修正は実装と同様にTDD（`/tdd-workflow`）で行う
-
-### 5. PR作成
+### 4. PR作成
 
 - PR作成前のコードpushはユーザーの承認を得てから実行する
 - `/commit-commands:commit-push-pr` を使用してPR作成を行う
+
+### 5. レビュー
+
+- `/code-review:code-review` プラグインを使用してコードレビューを実施する
+- レビューで指摘された項目をユーザーに提示し、修正が必要な箇所の指示を受ける
+- 修正は実装と同様にTDD（`/tdd-workflow`）で行う


### PR DESCRIPTION
## Summary

- Google Go Style Guideに準拠したClaude Code rulesファイルを追加
- `.claude/rules/backend/go-code-style.md`: 命名規則、エラーハンドリング、import、並行処理等のコードスタイル規約
- `.claude/rules/backend/go-testing.md`: テーブル駆動テスト、アサーション、失敗メッセージ形式等のテスト規約
- CLAUDE.mdの開発フローでレビューステップをPR作成後に移動

## Test plan

- [ ] `.claude/rules/backend/go-code-style.md` が存在し、設計原則・命名規則・エラーハンドリング等の全セクションを網羅していること
- [ ] `.claude/rules/backend/go-testing.md` が存在し、テスト命名・テーブル駆動テスト・アサーション規約等の全セクションを網羅していること
- [ ] いずれもGoogle Go Style Guideに準拠した汎用的な規約であること
- [ ] 簡潔で実行可能な指示であること

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)