### PR TITLE
CIパイプライン設定を追加

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,49 @@
+name: lint and test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:18.3
+        env:
+          POSTGRES_USER: ${{ secrets.TEST_POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.TEST_POSTGRES_DB }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ${{ secrets.TEST_POSTGRES_USER }} -d ${{ secrets.TEST_POSTGRES_DB }}"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt
+        run: |
+          diff=$(gofmt -l .)
+          if [ -n "$diff" ]; then
+            echo "$diff"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        env:
+          TEST_DATABASE_URL: postgres://${{ secrets.TEST_POSTGRES_USER }}:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.TEST_POSTGRES_DB }}?sslmode=disable
+        run: go test ./...

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,7 +20,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ${{ secrets.TEST_POSTGRES_USER }} -d ${{ secrets.TEST_POSTGRES_DB }}"
+          --health-cmd pg_isready
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ docker compose exec api go run ./cmd/ent
 
 - ユーザーが指定したIssue番号からGitHub Issuesを取得する
 - GitHubへのアクセスはMCPサーバー（`mcp__github`）を使用する
-- `main`ブランチから、Issue番号とタイトルに適した英語名で作業ブランチを作成する
-  - 例: `git switch -c "#1_fix_bugs"`
+- `main`ブランチから、Issue番号に `issue` プレフィックスを付けた英語名で作業ブランチを作成する
+  - 例: `git switch -c "issue1_fix_bugs"`
+  - `#` を含むブランチ名は GitHub Actions のジョブ生成が機能しないため使用しない
 
 ### 2. 設計
 


### PR DESCRIPTION
## Summary
- GitHub Actions による CI パイプラインを新規構築
- lint（gofmt / go vet）と test（PostgreSQL services + go test）を `.github/workflows/lint-and-test.yml` の単一ワークフローに統合
- PostgreSQL 認証情報は GitHub Actions secrets（`TEST_POSTGRES_USER` / `TEST_POSTGRES_PASSWORD` / `TEST_POSTGRES_DB`）経由で参照し、ハードコードを排除
- CLAUDE.md のブランチ命名規則を `issue<番号>_<英語名>` に変更（`#` 含むブランチで Actions が起動しない問題への対処）

## 経緯
当初は `#17_setup_ci_pipeline` ブランチで PR #21 を作成したが、GitHub Actions が `#` 入りブランチ名でジョブを生成できず CI が起動しない問題を確認した。CLAUDE.md のブランチ命名規則を `issue` プレフィックスに改めた上で、本ブランチで作り直している。旧ブランチ `#17_setup_ci_pipeline` および PR #21 は別途整理予定。

## Test plan
- [ ] PR 作成時に `lint and test` ワークフローが起動することを Checks 一覧で確認
- [ ] gofmt ステップで差分なし、`go vet ./...` がエラーなしで完了することを確認
- [ ] Postgres service が起動し、`internal/infrastructure/repository` 配下の統合テストを含む全テストが pass することを確認

閉じるIssue: #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)