### PR TITLE
特定書籍取得APIの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,107 @@
 # mare-scientiae
 
-過去に読んだ書籍の傾向から、次の一冊をおすすめするJSON API。
+過去に読んだ書籍の傾向から、次の一冊をおすすめする JSON API。フロントエンドは持たず、curl または CLI で実行する。レコメンドロジックは Claude API で実装し、将来的には AWS Lambda 上でのサーバレス実行を目指す。
+
+> [!NOTE]
+> 本リポジトリは Go 言語およびクリーンアーキテクチャ（DDD レイヤードアーキテクチャ）のキャッチアップを目的とした学習プロジェクトです。プロダクション利用は想定していません。
 
 ## 技術スタック
 
 - Go 1.26
-- MySQL 8.0
+- PostgreSQL 18.3
+- [Ent](https://entgo.io)（ORM・スキーママイグレーション）
 - Docker Compose
+- Claude API（将来的に導入予定）
+- AWS Lambda（将来的に導入予定）
+
+## アーキテクチャ
+
+DDD レイヤードアーキテクチャを採用し、依存方向は `presentation → usecase → domain ← infrastructure` を遵守する。実装は TDD（Red → Green → Refactoring）で行う。
+
+```
+cmd/
+  server/                 … HTTPサーバのエントリポイント（Composition Root）
+  lambda/                 … Lambda用エントリポイント（将来）
+  ent/                    … Ent マイグレーション実行用CLI
+internal/
+  domain/
+    model/                … エンティティ・値オブジェクト（外部依存なし）
+    repository/           … Repository interface + sentinel error
+  usecase/
+    interactor/           … ユースケース本体の実装
+    port/output/          … usecase が要求する外部サービス interface
+  infrastructure/
+    ent/                  … Ent スキーマ定義と生成コード
+    persistence/          … Repository interface の実装
+  presentation/
+    handler/              … HTTP ハンドラ（consumer interface も同居）
+    dto/                  … レスポンス/リクエスト DTO
+    router/               … ルーティング定義
+```
+
+詳細な設計指針・命名規則・interface 配置原則は [CLAUDE.md](./CLAUDE.md) および `.claude/rules/backend/` を参照。
+
+## 実装済みエンドポイント
+
+| メソッド | パス | 概要 | 対応 Issue |
+| --- | --- | --- | --- |
+| `GET` | `/v1/books` | 書籍一覧を取得 | [#19](https://github.com/posiposi/mare-scientiae/issues/19) |
+| `GET` | `/v1/books/{id}` | UUID をキーに書籍を 1 件取得 | [#24](https://github.com/posiposi/mare-scientiae/issues/24) |
+
+### レスポンス例
+
+```bash
+# 一覧取得
+curl http://localhost:8080/v1/books
+
+# 特定書籍取得
+curl http://localhost:8080/v1/books/87c50373-9d3e-4f71-8a92-b50af0633b1c
+```
+
+| ステータス | ケース | レスポンス |
+| --- | --- | --- |
+| 200 | 正常 | `BookResponse` JSON |
+| 400 | UUID 形式でない `id` | `{"error":"invalid_book_id"}` |
+| 404 | 該当レコードなし | `{"error":"book_not_found"}` |
+| 500 | 内部エラー | `{"error":"internal_server_error"}` |
+
+## これまでの主な実装履歴
+
+| # | タイトル | PR | 内容 |
+| --- | --- | --- | --- |
+| #13 | BookQueryRepository の追加 | [#18](https://github.com/posiposi/mare-scientiae/pull/18) | Book ドメインと一覧取得 Repository の基盤整備 |
+| #14 | Ent 導入 | [#16](https://github.com/posiposi/mare-scientiae/pull/16) | スキーマ管理ツールに Ent を採用 |
+| #17 | CI パイプライン整備 | [#21](https://github.com/posiposi/mare-scientiae/pull/21) | ビルド・vet・テストを GitHub Actions で実行 |
+| #19 | 書籍一覧取得 API | [#23](https://github.com/posiposi/mare-scientiae/pull/23) | `GET /v1/books` 実装 |
+| #24 | 特定書籍取得 API | [#27](https://github.com/posiposi/mare-scientiae/pull/27) | `GET /v1/books/{id}` 実装 |
+
+## 開発環境
+
+`api` / `db` / `test-db` の 3 サービスを Docker Compose で起動する。
+
+```bash
+# 初回・依存更新時
+docker compose up -d --build
+
+# 起動
+docker compose up -d
+
+# ビルド・静的解析・テストはすべて api コンテナ内で実行
+docker compose exec api go build ./...
+docker compose exec api gofmt -w .
+docker compose exec api go vet ./...
+docker compose exec api go test ./...
+
+# Ent クライアントコード生成
+docker compose exec api go generate ./internal/infrastructure/ent
+
+# マイグレーション実行（auto-migration は append-only）
+docker compose exec api go run ./cmd/ent
+```
+
+> [!IMPORTANT]
+> 現状ホットリロードは導入されていません。コード変更を反映するには `docker compose restart api` が必要です（[#28](https://github.com/posiposi/mare-scientiae/issues/28) で air の導入を検討中）。
+
+## 開発フロー
+
+Issue 取得 → 設計（`/design-workflow`）→ TDD 実装（`/tdd-workflow`）→ PR 作成（`/pull-request-creation`）→ レビュー（`/code-review:code-review`）の 5 段階で進める。詳細は [CLAUDE.md](./CLAUDE.md) を参照。

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,7 +48,8 @@ func run(_ context.Context) error {
 
 	bookRepo := persistence.NewBookRepository(client)
 	listBooksInteractor := interactor.NewListBooksInteractor(bookRepo)
-	bookHandler := handler.NewBookHandler(listBooksInteractor)
+	getBookInteractor := interactor.NewGetBookInteractor(bookRepo)
+	bookHandler := handler.NewBookHandler(listBooksInteractor, getBookInteractor)
 	mux := router.New(bookHandler)
 
 	log.Info().Str("addr", listenAddr).Msg("starting http server")

--- a/internal/domain/repository/book_repository.go
+++ b/internal/domain/repository/book_repository.go
@@ -2,10 +2,14 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"helloworld/internal/domain/model"
 )
 
+var ErrBookNotFound = errors.New("book: not found")
+
 type BookQueryRepositorier interface {
 	FindAll(ctx context.Context) ([]*model.Book, error)
+	FindByID(ctx context.Context, id model.BookID) (*model.Book, error)
 }

--- a/internal/infrastructure/persistence/book_repository.go
+++ b/internal/infrastructure/persistence/book_repository.go
@@ -36,11 +36,7 @@ func (r *BookRepository) FindAll(ctx context.Context) ([]*model.Book, error) {
 }
 
 func (r *BookRepository) FindByID(ctx context.Context, id model.BookID) (*model.Book, error) {
-	u, err := uuid.Parse(id.String())
-	if err != nil {
-		return nil, fmt.Errorf("parse book id (value=%q): %w", id.String(), err)
-	}
-	row, err := r.client.Book.Get(ctx, u)
+	row, err := r.client.Book.Get(ctx, uuid.MustParse(id.String()))
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, fmt.Errorf("find book (id=%s): %w", id.String(), repository.ErrBookNotFound)

--- a/internal/infrastructure/persistence/book_repository.go
+++ b/internal/infrastructure/persistence/book_repository.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
 	"helloworld/internal/infrastructure/ent"
 )
 
@@ -30,6 +33,21 @@ func (r *BookRepository) FindAll(ctx context.Context) ([]*model.Book, error) {
 		books = append(books, b)
 	}
 	return books, nil
+}
+
+func (r *BookRepository) FindByID(ctx context.Context, id model.BookID) (*model.Book, error) {
+	u, err := uuid.Parse(id.String())
+	if err != nil {
+		return nil, fmt.Errorf("parse book id (value=%q): %w", id.String(), err)
+	}
+	row, err := r.client.Book.Get(ctx, u)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, fmt.Errorf("find book (id=%s): %w", id.String(), repository.ErrBookNotFound)
+		}
+		return nil, fmt.Errorf("query book (id=%s): %w", id.String(), err)
+	}
+	return toDomainBook(row)
 }
 
 func toDomainBook(row *ent.Book) (*model.Book, error) {

--- a/internal/infrastructure/persistence/book_repository_test.go
+++ b/internal/infrastructure/persistence/book_repository_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
 )
 
 func TestBookRepository_FindAll_Empty(t *testing.T) {
@@ -132,6 +133,91 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func TestBookRepository_FindByID_ReturnsInsertedBook(t *testing.T) {
+	ctx := context.Background()
+	truncateBooks(ctx, t)
+
+	subtitle := "Tackling Complexity in the Heart of Software"
+	entBook, err := testClient.Book.Create().
+		SetGoogleBooksID("gbid-ddd").
+		SetTitle("Domain-Driven Design").
+		SetSubtitle(subtitle).
+		SetAuthors([]string{"Eric Evans"}).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+
+	id, err := model.NewBookID(entBook.ID.String())
+	if err != nil {
+		t.Fatalf("NewBookID: %v", err)
+	}
+
+	repo := NewBookRepository(testClient)
+	got, err := repo.FindByID(ctx, id)
+	if err != nil {
+		t.Fatalf("FindByID(%s) unexpected error: %v", id.String(), err)
+	}
+
+	if got.ID.String() != entBook.ID.String() {
+		t.Errorf("FindByID().ID = %q, want %q", got.ID.String(), entBook.ID.String())
+	}
+	if got.GoogleBooksID.String() != "gbid-ddd" {
+		t.Errorf("FindByID().GoogleBooksID = %q, want %q", got.GoogleBooksID.String(), "gbid-ddd")
+	}
+	if got.Title.String() != "Domain-Driven Design" {
+		t.Errorf("FindByID().Title = %q, want %q", got.Title.String(), "Domain-Driven Design")
+	}
+	if g := subtitleString(got.Subtitle); g != subtitle {
+		t.Errorf("FindByID().Subtitle = %q, want %q", g, subtitle)
+	}
+	if diff := cmp.Diff([]string{"Eric Evans"}, authorStrings(got.Authors)); diff != "" {
+		t.Errorf("FindByID().Authors mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBookRepository_FindByID_ReturnsErrBookNotFoundWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	truncateBooks(ctx, t)
+
+	id, err := model.NewBookID("22222222-2222-4222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("NewBookID: %v", err)
+	}
+
+	repo := NewBookRepository(testClient)
+	_, err = repo.FindByID(ctx, id)
+	if !errors.Is(err, repository.ErrBookNotFound) {
+		t.Errorf("FindByID() error = %v, want chain with %v", err, repository.ErrBookNotFound)
+	}
+}
+
+func TestBookRepository_FindByID_ErrorOnInvalidPersistedData(t *testing.T) {
+	ctx := context.Background()
+	truncateBooks(ctx, t)
+
+	entBook, err := testClient.Book.Create().
+		SetGoogleBooksID("gbid-empty-subtitle").
+		SetTitle("Title").
+		SetSubtitle("").
+		SetAuthors([]string{"Author"}).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+
+	id, err := model.NewBookID(entBook.ID.String())
+	if err != nil {
+		t.Fatalf("NewBookID: %v", err)
+	}
+
+	repo := NewBookRepository(testClient)
+	_, err = repo.FindByID(ctx, id)
+	if !errors.Is(err, model.ErrBookSubtitleEmpty) {
+		t.Errorf("FindByID() error = %v, want chain with %v", err, model.ErrBookSubtitleEmpty)
+	}
 }
 
 func TestBookRepository_FindAll_ErrorOnInvalidPersistedData(t *testing.T) {

--- a/internal/presentation/handler/book_handler.go
+++ b/internal/presentation/handler/book_handler.go
@@ -3,11 +3,13 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
 
 	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
 	"helloworld/internal/presentation/dto"
 )
 
@@ -15,12 +17,20 @@ type ListBooksUsecaser interface {
 	Execute(ctx context.Context) ([]*model.Book, error)
 }
 
-type BookHandler struct {
-	listBooksUsecase ListBooksUsecaser
+type GetBookUsecaser interface {
+	Execute(ctx context.Context, id model.BookID) (*model.Book, error)
 }
 
-func NewBookHandler(listBooksUsecase ListBooksUsecaser) *BookHandler {
-	return &BookHandler{listBooksUsecase: listBooksUsecase}
+type BookHandler struct {
+	listBooksUsecase ListBooksUsecaser
+	getBookUsecase   GetBookUsecaser
+}
+
+func NewBookHandler(listBooksUsecase ListBooksUsecaser, getBookUsecase GetBookUsecaser) *BookHandler {
+	return &BookHandler{
+		listBooksUsecase: listBooksUsecase,
+		getBookUsecase:   getBookUsecase,
+	}
 }
 
 func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
@@ -31,6 +41,26 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, dto.NewListBooksResponse(books))
+}
+
+func (h *BookHandler) GetBook(w http.ResponseWriter, r *http.Request) {
+	id, err := model.NewBookID(r.PathValue("id"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_book_id"})
+		return
+	}
+
+	book, err := h.getBookUsecase.Execute(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, repository.ErrBookNotFound) {
+			writeJSON(w, http.StatusNotFound, errorResponse{Error: "book_not_found"})
+			return
+		}
+		log.Error().Err(err).Str("book_id", id.String()).Msg("get book usecase failed")
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_server_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, dto.NewBookResponse(book))
 }
 
 type errorResponse struct {

--- a/internal/presentation/handler/book_handler_test.go
+++ b/internal/presentation/handler/book_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
 	"helloworld/internal/presentation/dto"
 	"helloworld/internal/presentation/handler"
 )
@@ -60,7 +61,7 @@ func TestBookHandler_ListBooks_Returns200WithBooksJSON(t *testing.T) {
 	book := buildBook(t, "11111111-1111-4111-8111-111111111111", "gbid-001", "DDD", &subtitle, []string{"Eric Evans"}, createdAt, updatedAt)
 
 	uc := &fakeListBooksUsecase{books: []*model.Book{book}}
-	h := handler.NewBookHandler(uc)
+	h := handler.NewBookHandler(uc, &fakeGetBookUsecase{})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/books", nil)
@@ -97,7 +98,7 @@ func TestBookHandler_ListBooks_Returns200WithBooksJSON(t *testing.T) {
 
 func TestBookHandler_ListBooks_ReturnsEmptyArrayWhenNoBooks(t *testing.T) {
 	uc := &fakeListBooksUsecase{books: []*model.Book{}}
-	h := handler.NewBookHandler(uc)
+	h := handler.NewBookHandler(uc, &fakeGetBookUsecase{})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/books", nil)
@@ -113,11 +114,110 @@ func TestBookHandler_ListBooks_ReturnsEmptyArrayWhenNoBooks(t *testing.T) {
 
 func TestBookHandler_ListBooks_Returns500WhenUsecaseFails(t *testing.T) {
 	uc := &fakeListBooksUsecase{err: errors.New("boom")}
-	h := handler.NewBookHandler(uc)
+	h := handler.NewBookHandler(uc, &fakeGetBookUsecase{})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/books", nil)
 	h.ListBooks(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+type fakeGetBookUsecase struct {
+	book *model.Book
+	err  error
+}
+
+func (f *fakeGetBookUsecase) Execute(_ context.Context, _ model.BookID) (*model.Book, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.book, nil
+}
+
+func newGetBookRequest(id string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/v1/books/"+id, nil)
+	req.SetPathValue("id", id)
+	return req
+}
+
+func TestBookHandler_GetBook_Returns200WithBookJSON(t *testing.T) {
+	createdAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 4, 21, 11, 0, 0, 0, time.UTC)
+	subtitle := "Tackling Complexity"
+	book := buildBook(t, "11111111-1111-4111-8111-111111111111", "gbid-001", "DDD", &subtitle, []string{"Eric Evans"}, createdAt, updatedAt)
+
+	getUC := &fakeGetBookUsecase{book: book}
+	h := handler.NewBookHandler(&fakeListBooksUsecase{}, getUC)
+
+	rec := httptest.NewRecorder()
+	h.GetBook(rec, newGetBookRequest("11111111-1111-4111-8111-111111111111"))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+
+	var got dto.BookResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	want := dto.BookResponse{
+		ID:            "11111111-1111-4111-8111-111111111111",
+		GoogleBooksID: "gbid-001",
+		Title:         "DDD",
+		Subtitle:      &subtitle,
+		Authors:       []string{"Eric Evans"},
+		CreatedAt:     createdAt,
+		UpdatedAt:     updatedAt,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("body mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBookHandler_GetBook_Returns400WhenIDIsInvalid(t *testing.T) {
+	h := handler.NewBookHandler(&fakeListBooksUsecase{}, &fakeGetBookUsecase{})
+
+	rec := httptest.NewRecorder()
+	h.GetBook(rec, newGetBookRequest("not-a-uuid"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+func TestBookHandler_GetBook_Returns404WhenNotFound(t *testing.T) {
+	getUC := &fakeGetBookUsecase{err: repository.ErrBookNotFound}
+	h := handler.NewBookHandler(&fakeListBooksUsecase{}, getUC)
+
+	rec := httptest.NewRecorder()
+	h.GetBook(rec, newGetBookRequest("22222222-2222-4222-8222-222222222222"))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+func TestBookHandler_GetBook_Returns500WhenUsecaseFails(t *testing.T) {
+	getUC := &fakeGetBookUsecase{err: errors.New("boom")}
+	h := handler.NewBookHandler(&fakeListBooksUsecase{}, getUC)
+
+	rec := httptest.NewRecorder()
+	h.GetBook(rec, newGetBookRequest("33333333-3333-4333-8333-333333333333"))
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)

--- a/internal/presentation/router/router.go
+++ b/internal/presentation/router/router.go
@@ -9,5 +9,6 @@ import (
 func New(bookHandler *handler.BookHandler) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/books", bookHandler.ListBooks)
+	mux.HandleFunc("GET /v1/books/{id}", bookHandler.GetBook)
 	return mux
 }

--- a/internal/usecase/interactor/get_book.go
+++ b/internal/usecase/interactor/get_book.go
@@ -1,0 +1,20 @@
+package interactor
+
+import (
+	"context"
+
+	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
+)
+
+type GetBookInteractor struct {
+	repo repository.BookQueryRepositorier
+}
+
+func NewGetBookInteractor(repo repository.BookQueryRepositorier) *GetBookInteractor {
+	return &GetBookInteractor{repo: repo}
+}
+
+func (u *GetBookInteractor) Execute(ctx context.Context, id model.BookID) (*model.Book, error) {
+	return u.repo.FindByID(ctx, id)
+}

--- a/internal/usecase/interactor/get_book_test.go
+++ b/internal/usecase/interactor/get_book_test.go
@@ -1,0 +1,84 @@
+package interactor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"helloworld/internal/domain/model"
+	"helloworld/internal/domain/repository"
+	"helloworld/internal/usecase/interactor"
+)
+
+type fakeBookFinder struct {
+	book *model.Book
+	err  error
+}
+
+func (f *fakeBookFinder) FindAll(_ context.Context) ([]*model.Book, error) {
+	return nil, nil
+}
+
+func (f *fakeBookFinder) FindByID(_ context.Context, _ model.BookID) (*model.Book, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.book, nil
+}
+
+func TestGetBookInteractor_Execute_ReturnsBookFromRepository(t *testing.T) {
+	book := newSampleBook(t)
+	repo := &fakeBookFinder{book: book}
+	uc := interactor.NewGetBookInteractor(repo)
+
+	got, err := uc.Execute(context.Background(), book.ID)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	opts := cmp.AllowUnexported(
+		model.Book{},
+		model.BookID{},
+		model.GoogleBooksID{},
+		model.BookTitle{},
+		model.BookSubtitle{},
+		model.Authors{},
+		model.Author{},
+	)
+	if diff := cmp.Diff(book, got, opts); diff != "" {
+		t.Errorf("Execute() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetBookInteractor_Execute_PropagatesNotFoundError(t *testing.T) {
+	repo := &fakeBookFinder{err: repository.ErrBookNotFound}
+	uc := interactor.NewGetBookInteractor(repo)
+
+	id, err := model.NewBookID("33333333-3333-4333-8333-333333333333")
+	if err != nil {
+		t.Fatalf("NewBookID: %v", err)
+	}
+
+	_, err = uc.Execute(context.Background(), id)
+	if !errors.Is(err, repository.ErrBookNotFound) {
+		t.Errorf("Execute() error = %v, want chain with %v", err, repository.ErrBookNotFound)
+	}
+}
+
+func TestGetBookInteractor_Execute_PropagatesRepositoryError(t *testing.T) {
+	wantErr := errors.New("repo failure")
+	repo := &fakeBookFinder{err: wantErr}
+	uc := interactor.NewGetBookInteractor(repo)
+
+	id, err := model.NewBookID("44444444-4444-4444-8444-444444444444")
+	if err != nil {
+		t.Fatalf("NewBookID: %v", err)
+	}
+
+	_, err = uc.Execute(context.Background(), id)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Execute() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/usecase/interactor/list_books_test.go
+++ b/internal/usecase/interactor/list_books_test.go
@@ -24,6 +24,10 @@ func (f *fakeBookQueryRepository) FindAll(_ context.Context) ([]*model.Book, err
 	return f.books, nil
 }
 
+func (f *fakeBookQueryRepository) FindByID(_ context.Context, _ model.BookID) (*model.Book, error) {
+	return nil, nil
+}
+
 func newSampleBook(t *testing.T) *model.Book {
 	t.Helper()
 	id, err := model.NewBookID("11111111-1111-4111-8111-111111111111")


### PR DESCRIPTION
## 概要
UUID をキーに書籍を 1 件取得する JSON API `GET /v1/books/{id}` を追加する。

## 変更内容
- domain/repository: `BookQueryRepositorier` に `FindByID` を追加し、`ErrBookNotFound` sentinel を定義
- infrastructure/persistence: `BookRepository.FindByID` を実装し、ent の NotFound エラーを `ErrBookNotFound` にマップ
- usecase: `GetBookInteractor` を追加
- presentation/handler: `BookHandler.GetBook` と `GetBookUsecaser` interface を追加。`NewBookHandler` を 2 引数化
- presentation/router: `GET /v1/books/{id}` を標準 `net/http.ServeMux` のパスパターンで登録
- cmd/server: `GetBookInteractor` を DI

## 動作確認
- `docker compose exec api go build ./...` が成功する
- `docker compose exec api go test ./...` が全パッケージで PASS する
- 200（正常）/ 400（不正 UUID 形式）/ 404（NotFound）/ 500（その他エラー）の各ケースを handler 単体テストで検証
- persistence 層の integration test で実 DB に対する FindByID の挙動を検証

## 関連Issue
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)